### PR TITLE
Changes fix issue of 'FatalExecutionEngineError receiving a sysex'

### DIFF
--- a/Source/Sanford.Multimedia.Midi/Device%20Classes/InputDevice%20Class/InputDevice.Construction.cs
+++ b/Source/Sanford.Multimedia.Midi/Device%20Classes/InputDevice%20Class/InputDevice.Construction.cs
@@ -1,0 +1,75 @@
+#region License
+
+/* Copyright (c) 2006 Leslie Sanford
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to 
+ * deal in the Software without restriction, including without limitation the 
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or 
+ * sell copies of the Software, and to permit persons to whom the Software is 
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ * THE SOFTWARE.
+ */
+
+#endregion
+
+#region Contact
+
+/*
+ * Leslie Sanford
+ * Email: jabberdabber@hotmail.com
+ */
+
+#endregion
+
+using System;
+using System.Threading;
+using Sanford.Threading;
+
+namespace Sanford.Multimedia.Midi
+{
+    public partial class InputDevice : MidiDevice
+    {
+        #region Construction
+
+        /// <summary>
+        /// Initializes a new instance of the InputDevice class with the 
+        /// specified device ID.
+        /// </summary>
+        public InputDevice(int deviceID) : base(deviceID)
+        {
+            midiInProc = HandleMessage;
+
+            delegateQueue = new DelegateQueue();
+            int result = midiInOpen(out handle, deviceID, midiInProc, IntPtr.Zero, CALLBACK_FUNCTION);
+
+            System.Diagnostics.Debug.WriteLine("MidiIn handle:" + handle.ToInt64());
+
+            if(result != MidiDeviceException.MMSYSERR_NOERROR)
+            {
+                throw new InputDeviceException(result);
+            }
+        }
+
+        ~InputDevice()
+        {
+            if(!IsDisposed)
+            {
+                midiInReset(handle);
+                midiInClose(handle);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Source/Sanford.Multimedia.Midi/Device%20Classes/InputDevice%20Class/InputDevice.Messaging.cs
+++ b/Source/Sanford.Multimedia.Midi/Device%20Classes/InputDevice%20Class/InputDevice.Messaging.cs
@@ -1,0 +1,286 @@
+#region License
+
+/* Copyright (c) 2005 Leslie Sanford
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to 
+ * deal in the Software without restriction, including without limitation the 
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or 
+ * sell copies of the Software, and to permit persons to whom the Software is 
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ * THE SOFTWARE.
+ */
+
+#endregion
+
+#region Contact
+
+/*
+ * Leslie Sanford
+ * Email: jabberdabber@hotmail.com
+ */
+
+#endregion
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Sanford.Multimedia;
+
+namespace Sanford.Multimedia.Midi
+{
+    public partial class InputDevice : MidiDevice
+    {
+        private void HandleMessage(IntPtr hnd, int msg, IntPtr instance, IntPtr param1, IntPtr param2)
+        {
+
+            //first send RawMessage
+            delegateQueue.Post(HandleRawMessage, param1.ToInt64());
+
+            if (msg == MIM_OPEN)
+            {
+            }
+            else if (msg == MIM_CLOSE)
+            {
+            }
+            else if (msg == MIM_DATA)
+            {
+                delegateQueue.Post(HandleShortMessage, param1.ToInt32());
+            }
+            else if (msg == MIM_MOREDATA)
+            {
+                delegateQueue.Post(HandleShortMessage, param1.ToInt32());
+            }
+            else if (msg == MIM_LONGDATA)
+            {
+                delegateQueue.Post(HandleSysExMessage, param1);
+            }
+            else if (msg == MIM_ERROR)
+            {
+                delegateQueue.Post(HandleInvalidShortMessage, param1.ToInt32());
+            }
+            else if (msg == MIM_LONGERROR)
+            {
+                delegateQueue.Post(HandleInvalidSysExMessage, param1);
+            }
+        }
+
+        private void HandleRawMessage(object state)
+        {
+            long param = (long)state;
+            OnRawMessage(new RawMessageEventArgs(unchecked((int)param)));
+        }
+
+        private void HandleShortMessage(object state)
+        {
+            int message = (int)state;
+            int status = ShortMessage.UnpackStatus(message);
+
+            if (status >= (int)ChannelCommand.NoteOff &&
+                status <= (int)ChannelCommand.PitchWheel +
+                ChannelMessage.MidiChannelMaxValue)
+            {
+                cmBuilder.Message = message;
+                cmBuilder.Build();
+
+                OnChannelMessageReceived(new ChannelMessageEventArgs(cmBuilder.Result));
+            }
+            else if (status == (int)SysCommonType.MidiTimeCode ||
+                status == (int)SysCommonType.SongPositionPointer ||
+                status == (int)SysCommonType.SongSelect ||
+                status == (int)SysCommonType.TuneRequest)
+            {
+                scBuilder.Message = message;
+                scBuilder.Build();
+
+                OnSysCommonMessageReceived(new SysCommonMessageEventArgs(scBuilder.Result));
+            }
+            else
+            {
+                SysRealtimeMessageEventArgs e = null;
+
+                switch ((SysRealtimeType)status)
+                {
+                    case SysRealtimeType.ActiveSense:
+                        e = SysRealtimeMessageEventArgs.ActiveSense;
+                        break;
+
+                    case SysRealtimeType.Clock:
+                        e = SysRealtimeMessageEventArgs.Clock;
+                        break;
+
+                    case SysRealtimeType.Continue:
+                        e = SysRealtimeMessageEventArgs.Continue;
+                        break;
+
+                    case SysRealtimeType.Reset:
+                        e = SysRealtimeMessageEventArgs.Reset;
+                        break;
+
+                    case SysRealtimeType.Start:
+                        e = SysRealtimeMessageEventArgs.Start;
+                        break;
+
+                    case SysRealtimeType.Stop:
+                        e = SysRealtimeMessageEventArgs.Stop;
+                        break;
+
+                    case SysRealtimeType.Tick:
+                        e = SysRealtimeMessageEventArgs.Tick;
+                        break;
+                }
+
+                OnSysRealtimeMessageReceived(e);
+            }
+        }
+
+        private void HandleSysExMessage(object state)
+        {
+            lock (lockObject)
+            {
+                IntPtr headerPtr = (IntPtr)state;
+
+                MidiHeader header = (MidiHeader)Marshal.PtrToStructure(headerPtr, typeof(MidiHeader));
+
+                if (!resetting)
+                {
+                    for (int i = 0; i < header.bytesRecorded; i++)
+                    {
+                        sysExData.Add(Marshal.ReadByte(header.data, i));
+                    }
+
+                    if (sysExData[0] == 0xF0 && sysExData[sysExData.Count - 1] == 0xF7)
+                    {
+                        SysExMessage message = new SysExMessage(sysExData.ToArray());
+
+                        sysExData.Clear();
+
+                        OnSysExMessageReceived(new SysExMessageEventArgs(message));
+                    }
+
+                    int result = AddSysExBuffer();
+
+                    if (result != DeviceException.MMSYSERR_NOERROR)
+                    {
+                        Exception ex = new InputDeviceException(result);
+
+                        OnError(new ErrorEventArgs(ex));
+                    }
+                }
+
+                ReleaseBuffer(headerPtr);
+            }
+        }
+
+        private void HandleInvalidShortMessage(object state)
+        {
+            OnInvalidShortMessageReceived(new InvalidShortMessageEventArgs((int)state));
+        }
+
+        private void HandleInvalidSysExMessage(object state)
+        {
+            lock (lockObject)
+            {
+                IntPtr headerPtr = (IntPtr)state;
+
+                MidiHeader header = (MidiHeader)Marshal.PtrToStructure(headerPtr, typeof(MidiHeader));
+
+                if (!resetting)
+                {
+                    byte[] data = new byte[header.bytesRecorded];
+
+                    Marshal.Copy(header.data, data, 0, data.Length);
+
+                    OnInvalidSysExMessageReceived(new InvalidSysExMessageEventArgs(data));
+
+                    int result = AddSysExBuffer();
+
+                    if (result != DeviceException.MMSYSERR_NOERROR)
+                    {
+                        Exception ex = new InputDeviceException(result);
+
+                        OnError(new ErrorEventArgs(ex));
+                    }
+                }
+
+                ReleaseBuffer(headerPtr);
+            }
+        }
+
+        private void ReleaseBuffer(IntPtr headerPtr)
+        {
+            int result = midiInUnprepareHeader(Handle, headerPtr, SizeOfMidiHeader);
+
+            if (result != DeviceException.MMSYSERR_NOERROR)
+            {
+                Exception ex = new InputDeviceException(result);
+
+                OnError(new ErrorEventArgs(ex));
+            }
+
+            headerBuilder.Destroy(headerPtr);
+
+            bufferCount--;
+
+            Debug.Assert(bufferCount >= 0);
+
+            Monitor.Pulse(lockObject);
+        }
+
+        public int AddSysExBuffer()
+        {
+            int result;
+
+            // Initialize the MidiHeader builder.
+            headerBuilder.BufferLength = sysExBufferSize;
+            headerBuilder.Build();
+
+            // Get the pointer to the built MidiHeader.
+            IntPtr headerPtr = headerBuilder.Result;
+
+            // Prepare the header to be used.
+            result = midiInPrepareHeader(Handle, headerPtr, SizeOfMidiHeader);
+
+            // If the header was perpared successfully.
+            if (result == DeviceException.MMSYSERR_NOERROR)
+            {
+                bufferCount++;
+
+                // Add the buffer to the InputDevice.
+                result = midiInAddBuffer(Handle, headerPtr, SizeOfMidiHeader);
+
+                // If the buffer could not be added.
+                if (result != MidiDeviceException.MMSYSERR_NOERROR)
+                {
+                    // Unprepare header - there's a chance that this will fail 
+                    // for whatever reason, but there's not a lot that can be
+                    // done at this point.
+                    midiInUnprepareHeader(Handle, headerPtr, SizeOfMidiHeader);
+
+                    bufferCount--;
+
+                    // Destroy header.
+                    headerBuilder.Destroy();
+                }
+            }
+            // Else the header could not be prepared.
+            else
+            {
+                // Destroy header.
+                headerBuilder.Destroy();
+            }
+
+            return result;
+        }
+    }
+}

--- a/Source/Sanford.Multimedia.Midi/Device%20Classes/InputDevice%20Class/InputDevice.Win32.cs
+++ b/Source/Sanford.Multimedia.Midi/Device%20Classes/InputDevice%20Class/InputDevice.Win32.cs
@@ -1,0 +1,95 @@
+#region License
+
+/* Copyright (c) 2006 Leslie Sanford
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to 
+ * deal in the Software without restriction, including without limitation the 
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or 
+ * sell copies of the Software, and to permit persons to whom the Software is 
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ * THE SOFTWARE.
+ */
+
+#endregion
+
+#region Contact
+
+/*
+ * Leslie Sanford
+ * Email: jabberdabber@hotmail.com
+ */
+
+#endregion
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Sanford.Multimedia.Midi
+{
+    public partial class InputDevice
+    {
+        // Represents the method that handles messages from Windows.
+        private delegate void MidiInProc(IntPtr handle, int msg, IntPtr instance, IntPtr param1, IntPtr param2);
+
+        #region Win32 MIDI Input Functions and Constants
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInOpen(out IntPtr handle, int deviceID,
+            MidiInProc proc, IntPtr instance, int flags);
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInClose(IntPtr handle);
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInStart(IntPtr handle);
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInStop(IntPtr handle);
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInReset(IntPtr handle);
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInPrepareHeader(IntPtr handle,
+            IntPtr headerPtr, int sizeOfMidiHeader);
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInUnprepareHeader(IntPtr handle,
+            IntPtr headerPtr, int sizeOfMidiHeader);
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInAddBuffer(IntPtr handle,
+            IntPtr headerPtr, int sizeOfMidiHeader);
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInGetDevCaps(int deviceID,
+            ref MidiInCaps caps, int sizeOfMidiInCaps);
+
+        [DllImport("winmm.dll")]
+        private static extern int midiInGetNumDevs();
+
+        private const int MIDI_IO_STATUS = 0x00000020;
+
+        private const int MIM_OPEN = 0x3C1;
+        private const int MIM_CLOSE = 0x3C2;
+        private const int MIM_DATA = 0x3C3;
+        private const int MIM_LONGDATA = 0x3C4;
+        private const int MIM_ERROR = 0x3C5;
+        private const int MIM_LONGERROR = 0x3C6;
+        private const int MIM_MOREDATA = 0x3CC;
+        private const int MHDR_DONE = 0x00000001;
+
+        #endregion        
+    }
+}

--- a/Source/Sanford.Multimedia.Midi/Messages/ShortMessage.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/ShortMessage.cs
@@ -60,7 +60,7 @@ namespace Sanford.Multimedia.Midi
 
         private const int StatusMask = ~255;
         protected const int DataMask = ~StatusMask;
-        private const int Data1Mask = ~65280;
+        private const int Data1Mask = ~65280; // 0xff00
         private const int Data2Mask = ~Data1Mask + DataMask;
         private const int Shift = 8;
 


### PR DESCRIPTION
These changes fix the fatal execution engine error on 64 bit environments by changing the declaration of the parameters that can carry pointers to C structures so they can handle the 64 bit pointers and at the same time, properly handle integer values that can be passed on the same parameters that pointers are passed.
