### PR TITLE
Apparently ShortMessage wasn't being written.

### DIFF
--- a/Source/Sanford.Multimedia.Midi/Sequencing/Track Classes/TrackWriter.cs
+++ b/Source/Sanford.Multimedia.Midi/Sequencing/Track Classes/TrackWriter.cs
@@ -96,6 +96,10 @@ namespace Sanford.Multimedia.Midi
                     case MessageType.SystemRealtime:
                         Write((SysRealtimeMessage)e.MidiMessage);
                         break;
+				
+		    case MessageType.Short:
+			Write((ShortMessage)e.MidiMessage);
+			break;
                 }
             }
 
@@ -137,6 +141,11 @@ namespace Sanford.Multimedia.Midi
                 count--;
             }
         }
+	    
+        private void Write(ShortMessage message)
+	{
+		trackData.AddRange(message.GetBytes());
+	}
 
         private void Write(ChannelMessage message)
         {


### PR DESCRIPTION
Maybe I am missing something, but when I saved a sequence none of the short messages were written into the file, thus I had no notes. I was able to track it down to this script, where a switch-case and method were missing.