### PR TITLE
Piano UI keys' maximum width

### DIFF
--- a/Source/Sanford.Multimedia.Midi/UI/PianoControl.PianoKey.cs
+++ b/Source/Sanford.Multimedia.Midi/UI/PianoControl.PianoKey.cs
@@ -172,6 +172,12 @@ namespace Sanford.Multimedia.Midi.UI
                 base.OnPaint(e);
             }
 
+            protected override void OnResize(EventArgs e)
+            {
+                Invalidate(); // Calls OnPaint while resizing to prevent design errors
+                base.OnResize(e);
+            }
+
             public Color NoteOnColor
             {
                 get

--- a/Source/Sanford.Multimedia.Midi/UI/PianoControl.cs
+++ b/Source/Sanford.Multimedia.Midi/UI/PianoControl.cs
@@ -197,24 +197,43 @@ namespace Sanford.Multimedia.Midi.UI
             int n = 0;
             int w = 0;
 
-            while(n < keys.Length)
+            int widthsum = 0; // Sum of white keys' width
+            int LastWhiteWidth = 0; // Last white key width
+            int remainder = Width % whiteKeyCount; // The remaining pixels
+            int counter = 1;
+            double step = remainder != 0 ? whiteKeyCount / (double)remainder : 0; // The ternary operator prevents a division by zero
+
+            while (n < keys.Length)
             {
-                if(KeyTypeTable[keys[n].NoteID] == KeyType.White)
+                if (KeyTypeTable[keys[n].NoteID] == KeyType.White)
                 {
+
                     keys[n].Height = Height;
                     keys[n].Width = whiteKeyWidth;
-                    keys[n].Location = new Point(w * whiteKeyWidth, 0);
+
+                    if (remainder != 0 && counter <= whiteKeyCount && Convert.ToInt32(step * counter) == w)
+                    {
+                        counter++;
+                        keys[n].Width++;
+                    }
+                    // See the Location property of black keys to understand
+                    widthsum += LastWhiteWidth;
+                    LastWhiteWidth = keys[n].Width;
+                    keys[n].Location = new Point(widthsum, 0);
+
                     w++;
-                    n++;
+                    //n++; // Move?
                 }
                 else
                 {
                     keys[n].Height = blackKeyHeight;
                     keys[n].Width = blackKeyWidth;
-                    keys[n].Location = new Point(offset + (w - 1) * whiteKeyWidth);
+                    keys[n].Location = new Point(widthsum + offset);
+                    //keys[n].Location = new Point(widthsum + offset - keys[n - 1].Width); // By this way, eliminates the LastWhiteWidth var
                     keys[n].BringToFront();
-                    n++;
+                    //n++; // Move?
                 }
+                n++; // Moved
             }
         }
 


### PR DESCRIPTION
When using this excellent library, I noticed that the Piano UI had some limitations caused by the fact that the WinForms Size values are integer types.
So I've made some changes to make the keys fills all the control size (PianoControl.cs) and force re-painting to prevent a resize glitch (PianoControl.PianoKey.cs).
As I'm a beginner, it can probably be improved, so I'll really appreciate your criticisms and suggestions.

![pianoui](https://cloud.githubusercontent.com/assets/29107591/26660569/45970c7a-464f-11e7-98a7-f108492f2669.png)
![synthesia](https://cloud.githubusercontent.com/assets/29107591/26660570/45973902-464f-11e7-976a-c1215b668ada.png)
