### PR TITLE
Clarify the mono only on windows situation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sanford.Multimedia.Midi
 This is all source code of the C# MIDI toolkit from CodeProject by Leslie Sanford.
 
 Improvements:
-- Mono compatible
+- Mono compatible ( Windows Only)
 - 64-bit compatible
 - Windows 8 and 10 compatible
 - Does not require additional assemblies


### PR DESCRIPTION
A simple change to the readme to clarify the fact that SMM will only run under mono on Windows due to it's reliance on Windows APIs.