### PR TITLE
Fix MidiHeader structure.

### DIFF
--- a/Source/Sanford.Multimedia.Midi/Device Classes/MidiHeader.cs
+++ b/Source/Sanford.Multimedia.Midi/Device Classes/MidiHeader.cs
@@ -40,7 +40,7 @@ namespace Sanford.Multimedia.Midi
     /// <summary>
     /// Represents the Windows Multimedia MIDIHDR structure.
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     internal struct MidiHeader
     {
         #region MidiHeader Members
@@ -53,23 +53,23 @@ namespace Sanford.Multimedia.Midi
         /// <summary>
         /// Size of the buffer.
         /// </summary>
-        public int bufferLength; 
+        public Int32 bufferLength; 
 
         /// <summary>
         /// Actual amount of data in the buffer. This value should be less than 
         /// or equal to the value given in the dwBufferLength member.
         /// </summary>
-        public int bytesRecorded; 
+        public Int32 bytesRecorded; 
 
         /// <summary>
         /// Custom user data.
         /// </summary>
-        public int user; 
+        public IntPtr user; 
 
         /// <summary>
         /// Flags giving information about the buffer.
         /// </summary>
-        public int flags; 
+        public Int32 flags; 
 
         /// <summary>
         /// Reserved; do not use.
@@ -79,7 +79,7 @@ namespace Sanford.Multimedia.Midi
         /// <summary>
         /// Reserved; do not use.
         /// </summary>
-        public int reserved; 
+        public IntPtr reserved; 
 
         /// <summary>
         /// Offset into the buffer when a callback is performed. (This 
@@ -88,13 +88,13 @@ namespace Sanford.Multimedia.Midi
         /// This offset enables an application to determine which 
         /// event caused the callback. 
         /// </summary>
-        public int offset; 
+        public Int32 offset; 
 
         /// <summary>
         /// Reserved; do not use.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst=8)]
-        public int[] reservedArray; 
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+        public IntPtr[] reservedArray; 
 
         #endregion
     }

--- a/Source/Sanford.Multimedia.Midi/Device Classes/MidiHeader.cs
+++ b/Source/Sanford.Multimedia.Midi/Device Classes/MidiHeader.cs
@@ -93,7 +93,7 @@ namespace Sanford.Multimedia.Midi
         /// <summary>
         /// Reserved; do not use.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst=4)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst=8)]
         public int[] reservedArray; 
 
         #endregion


### PR DESCRIPTION
SDK 10.0.16299.0  mmeapi.h  Ln.1029
```
/* MIDI data block header */
typedef struct midihdr_tag {
    LPSTR       lpData;               /* pointer to locked data block */
    DWORD       dwBufferLength;       /* length of data in data block */
    DWORD       dwBytesRecorded;      /* used for input only */
    DWORD_PTR   dwUser;               /* for client's use */
    DWORD       dwFlags;              /* assorted flags (see defines) */
    struct midihdr_tag far *lpNext;   /* reserved for driver */
    DWORD_PTR   reserved;             /* reserved for driver */

#if (WINVER >= 0x0400)
    DWORD       dwOffset;             /* Callback offset into buffer */
    DWORD_PTR   dwReserved[8];        /* Reserved for MMSYSTEM */
#endif
} MIDIHDR, *PMIDIHDR, NEAR *NPMIDIHDR, FAR *LPMIDIHDR;
```