### PR TITLE
Fix ExecutionEngineException caused by inconsistent Charset

### DIFF
--- a/Source/Sanford.Multimedia.Midi/Device Classes/InputDevice Class/InputDevice.Win32.cs
+++ b/Source/Sanford.Multimedia.Midi/Device Classes/InputDevice Class/InputDevice.Win32.cs
@@ -72,7 +72,7 @@ namespace Sanford.Multimedia.Midi
       private static extern int midiInAddBuffer(IntPtr handle,
           IntPtr headerPtr, int sizeOfMidiHeader);
 
-      [DllImport("winmm.dll")]
+      [DllImport("winmm.dll", CharSet = CharSet.Auto)]
       private static extern int midiInGetDevCaps(IntPtr deviceID,
           ref MidiInCaps caps, int sizeOfMidiInCaps);
 

--- a/Source/Sanford.Multimedia.Midi/Device Classes/InputDevice Class/MidiInCaps.cs
+++ b/Source/Sanford.Multimedia.Midi/Device Classes/InputDevice Class/MidiInCaps.cs
@@ -40,7 +40,7 @@ namespace Sanford.Multimedia.Midi
     /// <summary>
     /// Represents MIDI input device capabilities.
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Auto)]
     public struct MidiInCaps
     {
         #region MidiInCaps Members

--- a/Source/Sanford.Multimedia.Midi/Device Classes/OutputDevice Classes/MidiOutCaps.cs
+++ b/Source/Sanford.Multimedia.Midi/Device Classes/OutputDevice Classes/MidiOutCaps.cs
@@ -40,7 +40,7 @@ namespace Sanford.Multimedia.Midi
     /// <summary>
     /// Represents MIDI output device capabilities.
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Auto)]
     public struct MidiOutCaps
     {
         #region MidiOutCaps Members

--- a/Source/Sanford.Multimedia.Midi/Device Classes/OutputDevice Classes/OutputDeviceBase.cs
+++ b/Source/Sanford.Multimedia.Midi/Device Classes/OutputDevice Classes/OutputDeviceBase.cs
@@ -61,7 +61,7 @@ namespace Sanford.Multimedia.Midi
         protected static extern int midiOutLongMsg(IntPtr handle,
             IntPtr headerPtr, int sizeOfMidiHeader);
 
-        [DllImport("winmm.dll")]
+        [DllImport("winmm.dll", CharSet = CharSet.Auto)]
         protected static extern int midiOutGetDevCaps(IntPtr deviceID,
             ref MidiOutCaps caps, int sizeOfMidiOutCaps);
 


### PR DESCRIPTION
This should fix ExecutionEngineException on x86 calling midiInGetDevCaps.

And the previous PR about MidiHeader should be back because that should be correct and working.