### PR TITLE
Fix Ppqn Assertion in DEBUG.

### DIFF
--- a/Source/Sanford.Multimedia.Midi/Sequencing/MidiFileProperties.cs
+++ b/Source/Sanford.Multimedia.Midi/Sequencing/MidiFileProperties.cs
@@ -103,9 +103,14 @@ namespace Sanford.Multimedia.Midi
             format = trackCount = division = 0;
 
             FindHeader(strm);
-            Format = (int)ReadProperty(strm);
-            TrackCount = (int)ReadProperty(strm);
-            Division = (int)ReadProperty(strm);
+
+            // Division needs to be set first, otherwise AssertValid()
+            // will complain in DEBUG if sequence type is Ppqn.
+            int formatTmp = (int)ReadProperty(strm);
+            int trackCountTmp = (int)ReadProperty(strm);
+            Division = (int) ReadProperty(strm);
+            Format = formatTmp;
+            TrackCount = trackCountTmp;
 
             #region Invariant
 


### PR DESCRIPTION
Any `Ppqn` midi tracks will throw an assertion if `division` is less than `PpqnMinValue` when `AssertValid()` is called. `AssertValid()` is called in `set_Format` as well as `set_TrackCount` during `Read(Stream)` while `division` is set to 0 beforehand.

**Solution:** Set `Division` FIRST during `Read(Stream)`.