### PR TITLE
Track as sender of dispatched events of the Sequencer, AbsoluteTicks for all Message EventArgs

### DIFF
--- a/Source/Sanford.Multimedia.Midi.csproj
+++ b/Source/Sanford.Multimedia.Midi.csproj
@@ -136,6 +136,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Sanford.Multimedia.Midi\Device Classes\OutputDevice Classes\OutputDeviceBase.cs" />
+    <Compile Include="Sanford.Multimedia.Midi\Messages\EventArgs\MidiEventArgs.cs" />
     <Compile Include="Sanford.Multimedia.Midi\Messages\EventArgs\ShortMessageEventArgs.cs" />
     <Compile Include="Sanford.Multimedia.Midi\Messages\MidiEvents\InputDeviceMidiEvents.cs" />
     <Compile Include="Sanford.Multimedia.Midi\Messages\MidiEvents\MergeMidiEvents.cs" />

--- a/Source/Sanford.Multimedia.Midi/Messages/EventArgs/ChannelMessageEventArgs.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/EventArgs/ChannelMessageEventArgs.cs
@@ -4,13 +4,14 @@ using System.Text;
 
 namespace Sanford.Multimedia.Midi
 {
-    public class ChannelMessageEventArgs : EventArgs
+    public class ChannelMessageEventArgs : MidiEventArgs
     {
         private ChannelMessage message;
 
-        public ChannelMessageEventArgs(ChannelMessage message)
+        public ChannelMessageEventArgs(ChannelMessage message, int absoluteTicks = -1)
         {
             this.message = message;
+            this.AbsoluteTicks = absoluteTicks;
         }
 
         public ChannelMessage Message

--- a/Source/Sanford.Multimedia.Midi/Messages/EventArgs/InvalidShortMessageEventArgs.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/EventArgs/InvalidShortMessageEventArgs.cs
@@ -4,13 +4,14 @@ using System.Text;
 
 namespace Sanford.Multimedia.Midi
 {
-    public class InvalidShortMessageEventArgs : EventArgs
+    public class InvalidShortMessageEventArgs : MidiEventArgs
     {
         private int message;
 
-        public InvalidShortMessageEventArgs(int message)
+        public InvalidShortMessageEventArgs(int message, int absoluteTicks = -1)
         {
             this.message = message;
+            this.AbsoluteTicks = absoluteTicks;
         }
 
         public int Message

--- a/Source/Sanford.Multimedia.Midi/Messages/EventArgs/InvalidSysExMessageEventArgs.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/EventArgs/InvalidSysExMessageEventArgs.cs
@@ -4,13 +4,14 @@ using System.Text;
 
 namespace Sanford.Multimedia.Midi
 {
-    public class InvalidSysExMessageEventArgs : EventArgs
+    public class InvalidSysExMessageEventArgs : MidiEventArgs
     {
         private byte[] messageData;
 
-        public InvalidSysExMessageEventArgs(byte[] messageData)
+        public InvalidSysExMessageEventArgs(byte[] messageData, int absoluteTicks = -1)
         {
             this.messageData = messageData;
+            this.AbsoluteTicks = absoluteTicks;
         }
 
         public ICollection MessageData

--- a/Source/Sanford.Multimedia.Midi/Messages/EventArgs/MetaMessageEventArgs.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/EventArgs/MetaMessageEventArgs.cs
@@ -4,13 +4,14 @@ using System.Text;
 
 namespace Sanford.Multimedia.Midi
 {
-    public class MetaMessageEventArgs : EventArgs
+    public class MetaMessageEventArgs : MidiEventArgs
     {
         private MetaMessage message;
 
-        public MetaMessageEventArgs(MetaMessage message)
+        public MetaMessageEventArgs(MetaMessage message, int absoluteTicks = -1)
         {
             this.message = message;
+            this.AbsoluteTicks = absoluteTicks;
         }
 
         public MetaMessage Message

--- a/Source/Sanford.Multimedia.Midi/Messages/EventArgs/MidiEventArgs.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/EventArgs/MidiEventArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Sanford.Multimedia.Midi
+{
+    public class MidiEventArgs : EventArgs
+    {
+        public int AbsoluteTicks { get; set; }
+    }
+}

--- a/Source/Sanford.Multimedia.Midi/Messages/EventArgs/ShortMessageEventArgs.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/EventArgs/ShortMessageEventArgs.cs
@@ -7,24 +7,27 @@ namespace Sanford.Multimedia.Midi
     /// <summary>
     /// Raw short message as int or byte array, useful when working with VST.
     /// </summary>
-    public class ShortMessageEventArgs : EventArgs
+    public class ShortMessageEventArgs : MidiEventArgs
     {
         ShortMessage message;
 
-        public ShortMessageEventArgs(ShortMessage message)
+        public ShortMessageEventArgs(ShortMessage message, int absoluteTicks = -1)
         {
             this.message = message;
+            this.AbsoluteTicks = absoluteTicks;
         }
 
-        public ShortMessageEventArgs(int message, int timestamp = 0)
+        public ShortMessageEventArgs(int message, int timestamp = 0, int absoluteTicks = -1)
         {
             this.message = new ShortMessage(message);
             this.message.Timestamp = timestamp;
+            this.AbsoluteTicks = absoluteTicks;
         }
 
-        public ShortMessageEventArgs(byte status, byte data1, byte data2)
+        public ShortMessageEventArgs(byte status, byte data1, byte data2, int absoluteTicks = -1)
         {
             this.message = new ShortMessage(status, data1, data2);
+            this.AbsoluteTicks = absoluteTicks;
         }
 
         public ShortMessage Message

--- a/Source/Sanford.Multimedia.Midi/Messages/EventArgs/SysCommonMessageEventArgs.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/EventArgs/SysCommonMessageEventArgs.cs
@@ -4,13 +4,14 @@ using System.Text;
 
 namespace Sanford.Multimedia.Midi
 {
-    public class SysCommonMessageEventArgs : EventArgs
+    public class SysCommonMessageEventArgs : MidiEventArgs
     {
         private SysCommonMessage message;
 
-        public SysCommonMessageEventArgs(SysCommonMessage message)
+        public SysCommonMessageEventArgs(SysCommonMessage message, int absoluteTicks = -1)
         {
             this.message = message;
+            this.AbsoluteTicks = absoluteTicks;
         }
 
         public SysCommonMessage Message

--- a/Source/Sanford.Multimedia.Midi/Messages/EventArgs/SysExMessageEventArgs.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/EventArgs/SysExMessageEventArgs.cs
@@ -4,13 +4,14 @@ using System.Text;
 
 namespace Sanford.Multimedia.Midi
 {
-    public class SysExMessageEventArgs : EventArgs
+    public class SysExMessageEventArgs : MidiEventArgs
     {
         private SysExMessage message;
 
-        public SysExMessageEventArgs(SysExMessage message)
+        public SysExMessageEventArgs(SysExMessage message, int absoluteTicks = -1)
         {
             this.message = message;
+            this.AbsoluteTicks = absoluteTicks;
         }
 
         public SysExMessage Message

--- a/Source/Sanford.Multimedia.Midi/Messages/MessageDispatcher.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/MessageDispatcher.cs
@@ -84,15 +84,15 @@ namespace Sanford.Multimedia.Midi
                     break;
 
                 case MessageType.SystemExclusive:
-                    OnSysExMessageDispatched(new SysExMessageEventArgs((SysExMessage)message), track);
+                    OnSysExMessageDispatched(new SysExMessageEventArgs((SysExMessage)message, evt.AbsoluteTicks), track);
                     break;
 
                 case MessageType.Meta:
-                    OnMetaMessageDispatched(new MetaMessageEventArgs((MetaMessage)message), track);
+                    OnMetaMessageDispatched(new MetaMessageEventArgs((MetaMessage)message, evt.AbsoluteTicks), track);
                     break;
 
                 case MessageType.SystemCommon:
-                    OnSysCommonMessageDispatched(new SysCommonMessageEventArgs((SysCommonMessage)message), track);
+                    OnSysCommonMessageDispatched(new SysCommonMessageEventArgs((SysCommonMessage)message, evt.AbsoluteTicks), track);
                     break;
 
                 case MessageType.SystemRealtime:

--- a/Source/Sanford.Multimedia.Midi/Messages/MessageDispatcher.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/MessageDispatcher.cs
@@ -64,9 +64,11 @@ namespace Sanford.Multimedia.Midi
         /// <param name="message">
         /// The IMidiMessage to dispatch.
         /// </param>
-        public void Dispatch(IMidiMessage message)
+        public void Dispatch(MidiEvent evt, Track track)
         {
             #region Require
+
+            var message = evt.MidiMessage;
 
             if(message == null)
             {
@@ -78,50 +80,50 @@ namespace Sanford.Multimedia.Midi
             switch(message.MessageType)
             {
                 case MessageType.Channel:
-                    OnChannelMessageDispatched(new ChannelMessageEventArgs((ChannelMessage)message));
+                    OnChannelMessageDispatched(new ChannelMessageEventArgs((ChannelMessage)message, evt.AbsoluteTicks), track);
                     break;
 
                 case MessageType.SystemExclusive:
-                    OnSysExMessageDispatched(new SysExMessageEventArgs((SysExMessage)message));
+                    OnSysExMessageDispatched(new SysExMessageEventArgs((SysExMessage)message), track);
                     break;
 
                 case MessageType.Meta:
-                    OnMetaMessageDispatched(new MetaMessageEventArgs((MetaMessage)message));
+                    OnMetaMessageDispatched(new MetaMessageEventArgs((MetaMessage)message), track);
                     break;
 
                 case MessageType.SystemCommon:
-                    OnSysCommonMessageDispatched(new SysCommonMessageEventArgs((SysCommonMessage)message));
+                    OnSysCommonMessageDispatched(new SysCommonMessageEventArgs((SysCommonMessage)message), track);
                     break;
 
                 case MessageType.SystemRealtime:
                     switch(((SysRealtimeMessage)message).SysRealtimeType)
                     {
                         case SysRealtimeType.ActiveSense:
-                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.ActiveSense);
+                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.ActiveSense, track);
                             break;
 
                         case SysRealtimeType.Clock:
-                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Clock);
+                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Clock, track);
                             break;
 
                         case SysRealtimeType.Continue:
-                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Continue);
+                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Continue, track);
                             break;
 
                         case SysRealtimeType.Reset:
-                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Reset);
+                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Reset, track);
                             break;
 
                         case SysRealtimeType.Start:
-                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Start);
+                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Start, track);
                             break;
 
                         case SysRealtimeType.Stop:
-                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Stop);
+                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Stop, track);
                             break;
 
                         case SysRealtimeType.Tick:
-                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Tick);
+                            OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs.Tick, track);
                             break;
                     }
 
@@ -129,53 +131,53 @@ namespace Sanford.Multimedia.Midi
             }
         }
 
-        protected virtual void OnChannelMessageDispatched(ChannelMessageEventArgs e)
+        protected virtual void OnChannelMessageDispatched(ChannelMessageEventArgs e, Track track)
         {
             EventHandler<ChannelMessageEventArgs> handler = ChannelMessageDispatched;
 
             if(handler != null)
             {
-                handler(this, e);
+                handler(track, e);
             }
         }
 
-        protected virtual void OnSysExMessageDispatched(SysExMessageEventArgs e)
+        protected virtual void OnSysExMessageDispatched(SysExMessageEventArgs e, Track track)
         {
             EventHandler<SysExMessageEventArgs> handler = SysExMessageDispatched;
 
             if(handler != null)
             {
-                handler(this, e);
+                handler(track, e);
             }
         }
 
-        protected virtual void OnSysCommonMessageDispatched(SysCommonMessageEventArgs e)
+        protected virtual void OnSysCommonMessageDispatched(SysCommonMessageEventArgs e, Track track)
         {
             EventHandler<SysCommonMessageEventArgs> handler = SysCommonMessageDispatched;
 
             if(handler != null)
             {
-                handler(this, e);
+                handler(track, e);
             }
         }
 
-        protected virtual void OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs e)
+        protected virtual void OnSysRealtimeMessageDispatched(SysRealtimeMessageEventArgs e, Track track)
         {
             EventHandler<SysRealtimeMessageEventArgs> handler = SysRealtimeMessageDispatched;
 
             if(handler != null)
             {
-                handler(this, e);
+                handler(track, e);
             }
         }
 
-        protected virtual void OnMetaMessageDispatched(MetaMessageEventArgs e)
+        protected virtual void OnMetaMessageDispatched(MetaMessageEventArgs e, Track track)
         {
             EventHandler<MetaMessageEventArgs> handler = MetaMessageDispatched;
 
             if(handler != null)
             {
-                handler(this, e);
+                handler(track, e);
             }
         }
 

--- a/Source/Sanford.Multimedia.Midi/Sequencing/Track Classes/Track.Iterators.cs
+++ b/Source/Sanford.Multimedia.Midi/Sequencing/Track Classes/Track.Iterators.cs
@@ -66,7 +66,7 @@ namespace Sanford.Multimedia.Midi
             {
                 yield return enumerator.Current.AbsoluteTicks;
 
-                dispatcher.Dispatch(enumerator.Current.MidiMessage);
+                dispatcher.Dispatch(enumerator.Current, this);
             }
         }
 
@@ -98,7 +98,7 @@ namespace Sanford.Multimedia.Midi
                 }
                 else if(message.MessageType == MessageType.Meta)
                 {
-                    dispatcher.Dispatch(message);
+                    dispatcher.Dispatch(enumerator.Current, this);
                 }
 
                 notFinished = enumerator.MoveNext();
@@ -121,7 +121,7 @@ namespace Sanford.Multimedia.Midi
 
                 while(notFinished && enumerator.Current.AbsoluteTicks == ticks)
                 {
-                    dispatcher.Dispatch(enumerator.Current.MidiMessage);
+                    dispatcher.Dispatch(enumerator.Current, this);
 
                     notFinished = enumerator.MoveNext();    
                 }


### PR DESCRIPTION
**Track** now is the sender of raised events instead of the Dispatcher, adding **AbsoluteTicks** to  every MessageTypes' EventArgs by inheriting from the newly introduced "**MidiEventArgs**" that inherits from the former "**EventArgs**" base class