### PR TITLE
spelling fix in controller types

### DIFF
--- a/Source/Sanford.Multimedia.Midi/Messages/ChannelMessage.cs
+++ b/Source/Sanford.Multimedia.Midi/Messages/ChannelMessage.cs
@@ -337,9 +337,9 @@ namespace Sanford.Multimedia.Midi
         EffectsLevel = 91,
 
         /// <summary>
-        /// The Tremelo Level.
+        /// The Tremolo Level.
         /// </summary>
-        TremeloLevel,
+        TremoloLevel,
         
         /// <summary>
         /// The Chorus Level.


### PR DESCRIPTION
Edited controller type enum to correct a spelling error (Tremelo to trem**o**lo)