### PR TITLE
Fixes access violation in GetDeviceCapabilities

### DIFF
--- a/Source/Sanford.Multimedia.Midi/Device Classes/InputDevice Class/InputDevice.PublicMethods.cs
+++ b/Source/Sanford.Multimedia.Midi/Device Classes/InputDevice Class/InputDevice.PublicMethods.cs
@@ -187,7 +187,7 @@ namespace Sanford.Multimedia.Midi
             MidiInCaps caps = new MidiInCaps();
 
             IntPtr devID = (IntPtr)deviceID;
-            result = midiInGetDevCaps(devID, ref caps, SizeOfMidiHeader);
+            result = midiInGetDevCaps(devID, ref caps, MidiInCaps.SizeOf);
 
             if(result != MidiDeviceException.MMSYSERR_NOERROR)
             {

--- a/Source/Sanford.Multimedia.Midi/Device Classes/InputDevice Class/MidiInCaps.cs
+++ b/Source/Sanford.Multimedia.Midi/Device Classes/InputDevice Class/MidiInCaps.cs
@@ -40,9 +40,11 @@ namespace Sanford.Multimedia.Midi
     /// <summary>
     /// Represents MIDI input device capabilities.
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct MidiInCaps
     {
+        internal static readonly int SizeOf = Marshal.SizeOf(typeof(MidiInCaps));
+
         #region MidiInCaps Members
 
         /// <summary>


### PR DESCRIPTION
The method was calling midiInGetDevCaps with a wrong size argument. It passed the size of the MIDI header instead of size of the device CAPS. Due to recent fixes (#40) in regards to MIDI header size this issue now surfaced.

Initial issue came up here: https://forum.vvvv.org/t/silent-crash-on-7-1-0178/25040/4